### PR TITLE
Stock support for USI Life Support

### DIFF
--- a/GameData/StockPlugins/USILifeSupport.cfg
+++ b/GameData/StockPlugins/USILifeSupport.cfg
@@ -1,0 +1,223 @@
+// Make a copy of the fuel tanks from Squad
++PART[fuelTankSmallFlat]
+{
+	@name = StockLS_Tank_125
+	@author = RoverDude / Squad
+
+	@TechRequired = survivability
+	@entryCost = 3000
+	@cost = 500
+	@category = Utility
+	@title = Life Support Tank (1.25)
+	@manufacturer = Umbra Space Industries
+	@description = A tank filled to the brim with Nutritional Organic Meal Substitutes (N.O.M.S.).
+
+	@mass = 0.1
+	@crashTolerance = 7
+	@maxTemp = 2000 // = 3000
+	@bulkheadProfiles = size1,srf
+}
+
++PART[fuelTank4-2]
+{
+	@name = StockLS_Tank_250
+	@author = RoverDude / NovaSilisko
+
+	@TechRequired = survivability
+	@entryCost = 3000
+	@cost = 1000
+	@category = Utility
+	@title = Life Support Tank (2.5)
+	@manufacturer = Umbra Space Industries
+	@description = A tank filled to the brim with Nutritional Organic Meal Substitutes (N.O.M.S.).
+
+	@mass = 0.9
+	@minimum_drag = 0.2
+	@crashTolerance = 7
+	@maxTemp = 2000 // = 3000
+	@bulkheadProfiles = size2,srf
+}
+
++PART[Size3SmallTank]
+{
+	@name = StockLS_Tank_375
+	@author = RoverDude / Squad
+
+	@TechRequired = survivability
+	@entryCost = 3000
+	@cost = 1500
+	@category = Utility
+	@title = Life Support Tank (3.75)
+	@manufacturer = Umbra Space Industries
+	@description = A tank filled to the brim with Nutritional Organic Meal Substitutes (N.O.M.S.).
+
+	@mass = 3.0
+	@minimum_drag = 0.2
+	@crashTolerance = 7
+	@maxTemp = 2000 // = 3000
+	@bulkheadProfiles = size3,srf
+}
++PART[xenonTankRadial]
+{
+	@name = StockLS_Tank_Radial_Supplies
+	@author = RoverDude / Squad
+
+	@TechRequired = survivability
+	@entryCost = 1000
+	@cost = 100
+	@category = Utility
+	@title = Life Support MiniPak (Supplies)
+	@manufacturer = Umbra Space Industries
+	@description = While we firmly believe you can never have enough snacks, the engineers and load planners disagreed, and provided this smaller, more conveniently sized supply container.
+	
+	@attachRules = 0,1,0,0,0
+	@mass = 0.02
+	@maximum_drag = 0.25
+	@minimum_drag = 0.25
+	@angularDrag = .5
+	@crashTolerance = 45
+	@breakingForce = 280
+	@breakingTorque = 280
+	@maxTemp = 1700
+}
++PART[xenonTankRadial]
+{
+	@name = StockLS_Tank_Radial_Mulch
+	@author = RoverDude / Squad
+
+	@TechRequired = survivability
+	@entryCost = 1000
+	@cost = 100
+	@category = Utility
+	@title = Life Support MiniPak (Mulch)
+	@manufacturer = Umbra Space Industries
+	@description = When tossing stuff out the airlock is simply not an option.
+	
+	@attachRules = 0,1,0,0,0
+	@mass = 0.02
+	@maximum_drag = 0.25
+	@minimum_drag = 0.25
+	@angularDrag = .5
+	@crashTolerance = 45
+	@breakingForce = 280
+	@breakingTorque = 280
+	@maxTemp = 1700
+}
++PART[xenonTankRadial]
+{
+	@name = StockLS_Tank_Radial_Fertilizer
+	@author = RoverDude / Squad
+
+	@TechRequired = survivability
+	@entryCost = 1000
+	@cost = 100
+	@category = Utility
+	@title = Life Support MiniPak (Fertilizer)
+	@manufacturer = Umbra Space Industries
+	@description = For the larger Nom-O-Matic, provided a starter (Fertilizer) to dramatically extend life support capabilities.
+	
+	@attachRules = 0,1,0,0,0
+	@mass = 0.02
+	@maximum_drag = 0.25
+	@minimum_drag = 0.25
+	@angularDrag = .5
+	@crashTolerance = 45
+	@breakingForce = 280
+	@breakingTorque = 280
+	@maxTemp = 1700
+}
+
+// Fill the new fuel tanks with appropriate goodies
+@PART[StockLS_Tank_125]:NEEDS[USILifeSupport]
+{
+	-RESOURCE[LiquidFuel] {}
+	-RESOURCE[Oxidizer] {}
+	RESOURCE
+	{
+		name = Supplies
+		amount = 500
+		maxAmount = 500
+	}
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 10
+	}
+}
+
+@PART[StockLS_Tank_250]:NEEDS[USILifeSupport]
+{
+	-RESOURCE[LiquidFuel] {}
+	-RESOURCE[Oxidizer] {}
+	RESOURCE
+	{
+		name = Supplies
+		amount = 4500
+		maxAmount = 4500
+	}
+
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 150
+	}
+}
+
+@PART[StockLS_Tank_375]:NEEDS[USILifeSupport]
+{
+	-RESOURCE[LiquidFuel] {}
+	-RESOURCE[Oxidizer] {}
+	RESOURCE
+	{
+		name = Supplies
+		amount = 15000
+		maxAmount = 15000
+	}
+
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 300
+	}
+}
+
+@PART[StockLS_Tank_Radial_Supplies]:NEEDS[USILifeSupport]
+{
+	-RESOURCE[XenonGas] {}
+	RESOURCE
+	{
+		name = Supplies
+		amount = 100
+		maxAmount = 100
+	}
+}
+@PART[StockLS_Tank_Radial_Mulch]:NEEDS[USILifeSupport]
+{
+	-RESOURCE[XenonGas] {}
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 100
+	}
+}
+@PART[StockLS_Tank_Radial_Fertilizer]:NEEDS[USILifeSupport]
+{
+	-RESOURCE[XenonGas] {}
+	RESOURCE
+	{
+		name = Fertilizer
+		amount = 100
+		maxAmount = 100
+	}
+}
+
+// Disable the USI Lifesupport parts.
+@PART[LS_Tank_125|LS_Tank_250|LS_Tank_375|LifeSupportMiniPack|MulchMiniPack|FertilizerMiniPack]:NEEDS[USILifeSupport]
+{
+	@TechRequired = unassigned
+	@category = none
+}


### PR DESCRIPTION
This is just a first attempt for feedback. It uses the smallest of the three sized tanks instead of the nice pretty parts from USI Life Support, but it doesn't break if you remove USI Life Support. It also uses the radial mounted Xenon tanks for the minipacks. 

The only problem with cloning is that this introduces a hard dependency on MM that wasn't there before. I'm open to other ideas though!
